### PR TITLE
Update AppenderFactory.java

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AppenderFactory.java
@@ -16,7 +16,7 @@ import io.dropwizard.logging.common.layout.LayoutFactory;
  * <ol>
  * <li>Create a class which implements {@link AppenderFactory}.</li>
  * <li>Annotate it with {@code @JsonTypeName} and give it a unique type name.</li>
- * <li>add a {@code META-INF/services/io.dropwizard.logging.AppenderFactory} file with your
+ * <li>add a {@code META-INF/services/io.dropwizard.logging.common.AppenderFactory} file with your
  * implementation's full class name to the class path.</li>
  * </ol>
  *


### PR DESCRIPTION
###### Problem:
The javadocs for including the AppenderFactory service haven't been updated after package refactor

###### Solution:
Update javadocs to refer to the service as `io.dropwizard.logging.common.AppenderFactory`

###### Result:
Correct docs
